### PR TITLE
Cleaning up build system; making more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ INCLUDE_DIR := ./src/include
 #each file type needs to be located separatly because duplicate
 #names will mess up the search if I try to do it in one command
 
-#ASM_SRC_FILES := $(wildcard  $(SRC_DIR)/*.asm) 
-#C_SRC_FILES := $(wildcard $(SRC_DIR)/*.c) 
-#CPP_SRC_FILES := $(wildcard $(SRC_DIR)/*.cpp)
-
 ASM_SRC_FILES := $(wildcard $(SRC_DIR)/*.asm) $(wildcard $(SRC_DIR)/*/*.asm) $(wildcard $(SRC_DIR)/*/*/*.asm)
 CPP_SRC_FILES := $(wildcard $(SRC_DIR)/*.cpp) $(wildcard $(SRC_DIR)/*/*.cpp) $(wildcard $(SRC_DIR)/*/*/*.cpp)
 C_SRC_FILES := $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/*/*.c) $(wildcard $(SRC_DIR)/*/*/*.c)
@@ -37,7 +33,7 @@ OBJ_FILES := $(subst $(SRC_DIR), $(OBJS_DIR), $(addsuffix .o, $(basename $(SRC_F
 OUTPUT_FILE = $(BIN_DIR)/kernel.bin
 
 #flags used by both compilers
-COMMON_FLAGS = -c -O2 -ffreestanding -lgcc -Werror -Wall -Wextra -I$(INCLUDE_DIR)
+COMMON_FLAGS = -c -O2 -ffreestanding -lgcc -fno-pic -Werror -Wall -Wextra -I$(INCLUDE_DIR)
 
 #The compiler and its flags
 CC = i686-elf-gcc
@@ -67,25 +63,19 @@ $(OUTPUT_FILE) : $(OBJ_FILES)
 
 # assemble any .asm files and put them in the OBJS_DIR
 $(OBJS_DIR)/%.o : $(SRC_DIR)/%.asm
-	mkdir -p $(OBJS_DIR)/arch/x86
-	mkdir -p $(OBJS_DIR)/drivers
-	mkdir -p $(OBJS_DIR)/libc
-	$(ASM) $(ASMFLAGS) $^ -o $@
-	echo "$^  ----->  $@"
+	mkdir -p $(dir $@)
+	$(ASM) $(ASMFLAGS) $< -o $@
+	echo "$<  ----->  $@"
 
 #compile any .c files and put them in the OBJS_DIR
 $(OBJS_DIR)/%.o : $(SRC_DIR)/%.c 
-	mkdir -p $(OBJS_DIR)/arch/x86
-	mkdir -p $(OBJS_DIR)/drivers
-	mkdir -p $(OBJS_DIR)/libc
+	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $< -o $@
 	echo "$<  ----->  $@"
 
 #compiile and .cpp files and put them in the OBJS_DIR
 $(OBJS_DIR)/%.o : $(SRC_DIR)/%.cpp 
-	mkdir -p $(OBJS_DIR)/arch/x86
-	mkdir -p $(OBJS_DIR)/drivers
-	mkdir -p $(OBJS_DIR)/libc
+	mkdir -p $(dir $@)
 	$(CPP) $(CPPFLAGS) $< -o $@
 	echo "$<  ----->  $@"
 
@@ -126,10 +116,11 @@ clean:
 	rm -f $(BIN_DIR)/*~ $(BIN_DIR)/*.bin
 
 print:
-	figlet -c Twilight
+	# don't fail if figlet isn't installed
+	if which figlet >/dev/null; then figlet -c Twilight; else echo "                        ##### Twilight #####"; fi
 	
 run:
 	echo "Starting QEMU"
 	#qemu-system-i386 -kernel $(OUTPUT_FILE) -serial stdio
-	powershell.exe start scripts/run_qemu.bat
+	cmd.exe /C "scripts\run_qemu.bat"
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJ_FILES := $(subst $(SRC_DIR), $(OBJS_DIR), $(addsuffix .o, $(basename $(SRC_F
 OUTPUT_FILE = $(BIN_DIR)/kernel.bin
 
 #flags used by both compilers
-COMMON_FLAGS = -c -O2 -ffreestanding -lgcc -fno-pic -Werror -Wall -Wextra -I$(INCLUDE_DIR)
+COMMON_FLAGS = -g -c -O0 -ffreestanding -lgcc -fno-pic -Werror -Wall -Wextra -I$(INCLUDE_DIR)
 
 #The compiler and its flags
 CC = i686-elf-gcc
@@ -44,11 +44,11 @@ CPP = i686-elf-c++
 CPPFLAGS = -fno-exceptions -std=c++17 $(COMMON_FLAGS) -fno-rtti
 
 #Linker Flags
-LDFLAGS = -T link.ld -ffreestanding -O2 -lgcc -nostdlib
+LDFLAGS = -T link.ld -ffreestanding -O0 -lgcc -nostdlib
 
 #The assembler and its flags
 ASM = nasm
-ASMFLAGS = -felf32
+ASMFLAGS = -felf32 -F dwarf -g
 
 #GCC assembler does not need flags
 #ASM=i686-elf-as

--- a/gdb.script
+++ b/gdb.script
@@ -1,0 +1,5 @@
+# Run by starting qemu with "-s -S" parameters. Then run the following command:
+# gdb -tui -command=gdb.script
+target remote localhost:1234
+file bin/kernel.bin
+advance start

--- a/link.ld
+++ b/link.ld
@@ -1,7 +1,6 @@
 
 /* i'm pretty sure this script only looks for symbols and places them in memory the way thay've been outlind below */
 
-OUTPUT_FORMAT("binary") /* the output file type is described here */
 ENTRY(start) /* search for this symbol and make it the entry point */
 phys = 0x00100000; /* the address to start at I guess? */
 SECTIONS

--- a/scripts/run_qemu.bat
+++ b/scripts/run_qemu.bat
@@ -3,4 +3,5 @@ rem The windows command prompt will use the same working directory as we ran mak
 
 set QEMU="C:\Installed_Programs\qemu\qemu-system-i386.exe"
 
-%QEMU% -kernel "bin\kernel.bin" -serial stdio
+%QEMU% -kernel "bin\kernel.bin" -S -s -serial stdio
+rem %QEMU% -kernel "bin\kernel.bin" -serial stdio

--- a/scripts/run_qemu.bat
+++ b/scripts/run_qemu.bat
@@ -1,5 +1,6 @@
 rem Go run the qemu program with the kernel
-rem Remember to fix this if the file path changes.
+rem The windows command prompt will use the same working directory as we ran make from
 
-cd \Installed_Programs\qemu
-qemu-system-i386.exe -kernel "\Programming\OS\TwilightOS\bin\kernel.bin" -serial stdio
+set QEMU="C:\Installed_Programs\qemu\qemu-system-i386.exe"
+
+%QEMU% -kernel "bin\kernel.bin" -serial stdio


### PR DESCRIPTION
* Adding -fno-pic, so gcc doesn't attempt to generate position-independent code
* Using cmd instead of powershell, because cmd preserves the working directory
* Doesn't require figlet in order to build